### PR TITLE
Add support for extending tsconfigs

### DIFF
--- a/src/ng_module.bzl
+++ b/src/ng_module.bzl
@@ -7,6 +7,7 @@
 
 load(":rules_typescript.bzl",
     "tsc_wrapped_tsconfig",
+    "TsConfigInfo",
     "COMMON_ATTRIBUTES",
     "COMMON_OUTPUTS",
     "compile_ts",
@@ -228,6 +229,8 @@ def _compile_action(ctx, inputs, outputs, messages_out, tsconfig_file, node_opts
   # If the user supplies a tsconfig.json file, the Angular compiler needs to read it
   if hasattr(ctx.attr, "tsconfig") and ctx.file.tsconfig:
     file_inputs.append(ctx.file.tsconfig)
+    if TsConfigInfo in ctx.attr.tsconfig:
+      file_inputs.extend(ctx.attr.tsconfig[TsConfigInfo].deps)
 
   # Collect the inputs and summary files from our deps
   action_inputs = depset(file_inputs,

--- a/src/rules_typescript.bzl
+++ b/src/rules_typescript.bzl
@@ -4,6 +4,9 @@
 load("@build_bazel_rules_typescript//internal:build_defs.bzl",
     _tsc_wrapped_tsconfig = "tsc_wrapped_tsconfig",
 )
+load("@build_bazel_rules_typescript//internal:ts_config.bzl",
+    _TsConfigInfo = "TsConfigInfo",
+)
 
 load("@build_bazel_rules_typescript//internal:common/compilation.bzl",
     _COMMON_ATTRIBUTES = "COMMON_ATTRIBUTES",
@@ -24,3 +27,4 @@ compile_ts = _compile_ts
 DEPS_ASPECTS = _DEPS_ASPECTS
 ts_providers_dict_to_struct = _ts_providers_dict_to_struct
 json_marshal = _json_marshal
+TsConfigInfo = _TsConfigInfo


### PR DESCRIPTION
This basically mirrors the way rules_typescript ([build_defs.bzl#L46-L49](https://github.com/bazelbuild/rules_typescript/blob/924782af55f2396d9bdc9e0a9904fe2d4b3b9047/internal/build_defs.bzl#L46-L49)) handles extended tsconfigs.